### PR TITLE
Improve NA robustness in VectorPlotter.comp_data (#2417)

### DIFF
--- a/doc/releases/v0.12.0.txt
+++ b/doc/releases/v0.12.0.txt
@@ -4,7 +4,9 @@ v0.12.0 (Unreleased)
 
 - |API| |Feature| |Enhancement| TODO (Flesh this out further). Increased flexibility of what can be shown by the internally-calculated errorbars (:pr:2407).
 
-- Made `scipy` an optional dependency and added `pip install seaborn[all]` as a method for ensuring the availability of compatible `scipy` and `statsmodels` libraries. This has a few minor implications for existing code, which are explained in the Github pull request (:pr:`2398`).
+- |Fix| |Enhancement| Improved robustness to missing data, including additional support for the `pd.NA` type (:pr:`2417).
+
+- Made `scipy` an optional dependency and added `pip install seaborn[all]` as a method for ensuring the availability of compatible `scipy` and `statsmodels` libraries at install time. This has a few minor implications for existing code, which are explained in the Github pull request (:pr:`2398`).
 
 - Following `NEP29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_, dropped support for Python 3.6 and bumped the minimally-supported versions of the library dependencies.
 

--- a/seaborn/_core.py
+++ b/seaborn/_core.py
@@ -1048,10 +1048,16 @@ class VectorPlotter:
                     ax = self.ax
                 axis = getattr(ax, f"{var}axis")
 
-                comp_var = axis.convert_units(self.plot_data[var])
+                # Use the converter assigned to the axis to get a float representation
+                # of the data, passing np.nan or pd.NA through (pd.NA becomes np.nan)
+                with pd.option_context('mode.use_inf_as_null', True):
+                    orig = self.plot_data[var].dropna()
+                comp_col = pd.Series(index=orig.index, dtype=float, name=var)
+                comp_col.loc[orig.index] = pd.to_numeric(axis.convert_units(orig))
+
                 if axis.get_scale() == "log":
-                    comp_var = np.log10(comp_var)
-                comp_data.insert(0, var, comp_var)
+                    comp_col = np.log10(comp_col)
+                comp_data.insert(0, var, comp_col)
 
             self._comp_data = comp_data
 

--- a/seaborn/tests/test_core.py
+++ b/seaborn/tests/test_core.py
@@ -1,3 +1,4 @@
+import itertools
 import numpy as np
 import pandas as pd
 import matplotlib as mpl
@@ -22,6 +23,12 @@ from .._core import (
 )
 
 from ..palettes import color_palette
+
+
+try:
+    from pandas import NA as PD_NA
+except ImportError:
+    PD_NA = None
 
 
 @pytest.fixture(params=[
@@ -1201,6 +1208,50 @@ class TestVectorPlotter:
             p.comp_data["x"],
             [2, 0, 1, 2],
         )
+
+    @pytest.fixture(
+        params=itertools.product(
+            [None, np.nan, PD_NA],
+            ["numeric", "category", "datetime"]
+        )
+    )
+    @pytest.mark.parametrize(
+        "NA,var_type",
+    )
+    def comp_data_missing_fixture(self, request):
+
+        # This fixture holds the logic for parametrizing
+        # the following test (test_comp_data_missing)
+
+        NA, var_type = request.param
+
+        if NA is None:
+            pytest.skip("No pandas.NA available")
+
+        comp_data = [0, 1, np.nan, 2, np.nan, 1]
+        if var_type == "numeric":
+            orig_data = [0, 1, NA, 2, np.inf, 1]
+        elif var_type == "category":
+            orig_data = ["a", "b", NA, "c", NA, "b"]
+        elif var_type == "datetime":
+            # Use 1-based numbers to avoid issue on matplotlib<3.2
+            # Could simplify the test a bit when we roll off that version
+            comp_data = [1, 2, np.nan, 3, np.nan, 2]
+            numbers = [1, 2, 3, 2]
+
+            orig_data = mpl.dates.num2date(numbers)
+            orig_data.insert(2, NA)
+            orig_data.insert(4, np.inf)
+
+        return orig_data, comp_data
+
+    def test_comp_data_missing(self, comp_data_missing_fixture):
+
+        orig_data, comp_data = comp_data_missing_fixture
+        p = VectorPlotter(variables={"x": orig_data})
+        ax = plt.figure().subplots()
+        p._attach(ax)
+        assert_array_equal(p.comp_data["x"], comp_data)
 
     def test_var_order(self, long_df):
 


### PR DESCRIPTION
* Improve NA robustness in VectorPlotter.comp_data

* Adjust datetime test to account for archaic matplotlib limitation

* Update release notes